### PR TITLE
Ks/fix docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 [![Documentation](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/docs.yaml/badge.svg)](https://proteus-framework.org/ZEPHYRUS/)
 ![Coverage](https://gist.githubusercontent.com/lsoucasse/152250f71914339d24537977e64aba55/raw/covbadge_zephyrus.svg)
 
-![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_white.png#gh-light-mode-only)
-![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_black.png#gh-dark-mode-only)
+![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_white.png#only-light)
+![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_black.png#only-dark)
 
 
 # ZEPHYRUS for atmospheric escape

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,13 +12,15 @@ nav:
   - 🔗 PROTEUS: https://proteus-framework.org/PROTEUS/
   - 🔗 JANUS: https://proteus-framework.org/JANUS/
   - 🔗 CALLIOPE: https://proteus-framework.org/CALLIOPE/
-  - 🔗 MORS: https://proteus-framework.org/MORS/
-  - 🔗 AGNI: https://h-nicholls.space/AGNI/dev/
-  - 🔗 Obliqua: https://proteus-framework.org/Obliqua/ 
-  - 🔗 VULCAN: https://github.com/FormingWorlds/VULCAN
+  - 🔗 AGNI: https://www.h-nicholls.space/AGNI/
+  - 🔗 Obliqua: https://proteus-framework.org/Obliqua/
+  - 🔗 VULCAN: https://proteus-framework/VULCAN/
   - 🔗 Zalmoxis: https://proteus-framework.org/Zalmoxis/
   - 🔗 Aragog: https://proteus-framework.org/aragog/
   - 🔗 SPIDER: https://github.com/djbower/spider
+  - 🔗 Atmodeller: https://atmodeller.readthedocs.io/en/latest/
+  - 🔗 FastChem: https://newstrangeworlds.github.io/FastChem/
+  - 🔗 PLATON: https://platon.readthedocs.io/en/latest/
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,7 +85,10 @@ plugins:
             ignore_init_summary: yes
           show_submodules: no
           show_source: true
-          show_root_heading: false
+          show_symbol_type_heading: True
+          show_root_heading: true
+          show_root_toc_entry: true
+          show_docstring_attributes: true
           show_root_full_path: false
           docstring_section_style: list
           members_order: alphabetical


### PR DESCRIPTION
## Description
This is my second attempt at fixing the documentation issue, where the documentation menu does not appear in the final documentation (even so it does in the local build).

I:
- added three lines in mkdocs that were there for proteus but not for zephyrus
- fixed the double logo
- added some links

## Validation of changes
Built documentation locally.


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people
@EmmaPostolec 
