### PR TITLE
Fix images 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Documentation](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/docs.yaml/badge.svg)](https://proteus-framework.org/ZEPHYRUS/)
 ![Coverage](https://gist.githubusercontent.com/lsoucasse/152250f71914339d24537977e64aba55/raw/covbadge_zephyrus.svg)
 
-![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_white.png#gh-light-mode-only)
-![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_black.png#gh-dark-mode-only)
+![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/assets/ZEPHYRUS_logo_white.png#gh-light-mode-only)
+![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/assets/ZEPHYRUS_logo_black.png#gh-dark-mode-only)
 
 
 # ZEPHYRUS for atmospheric escape

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@
 [![License](https://img.shields.io/github/license/FormingWorlds/ZEPHYRUS?label=License)](https://github.com/FormingWorlds/ZEPHYRUS/blob/main/LICENSE.md)
 [![PyPI](https://img.shields.io/pypi/v/fwl-zephyrus?label=PyPI)](https://pypi.org/project/fwl-zephyrus/)
 
-![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_white.png#only-light)
-![ZEPHYRUS banner](https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/main/docs/logo/ZEPHYRUS_logo_black.png#only-dark)
+![ZEPHYRUS banner](assets/ZEPHYRUS_logo_white.png#only-light)
+![ZEPHYRUS banner](assets/ZEPHYRUS_logo_black.png#only-dark)
 
 
 **Zephyrus**, named after the Greek God of the West wind and messenger of spring, models the energy-limited atmospheric escape of exoplanets. 

--- a/docs/proteus_framework.md
+++ b/docs/proteus_framework.md
@@ -12,9 +12,8 @@ ZEPHYRUS is the atmospheric escape module of <b>PROTEUS</b> (/ˈproʊtiəs, PROH
 <br>
 Click any module in the diagram to open its documentation, or navigate to it from the sidebar.
 <br>
-<br>
 
-<object type="image/svg+xml" data="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus_modules_schematic.svg" class="arch-diagram arch-diagram--light"></object>
-<object type="image/svg+xml" data="https://raw.githubusercontent.com/FormingWorlds/PROTEUS/main/docs/assets/proteus_modules_schematic_darkmode.svg" class="arch-diagram arch-diagram--dark"></object>
+<object type="image/svg+xml" data="https://cdn.jsdelivr.net/gh/FormingWorlds/PROTEUS@main/docs/assets/proteus_modules_schematic.svg" class="mod-diagram mod-diagram--light"></object>
+<object type="image/svg+xml" data="https://cdn.jsdelivr.net/gh/FormingWorlds/PROTEUS@main/docs/assets/proteus_modules_schematic_darkmode.svg" class="mod-diagram mod-diagram--dark"></object>
 
 <p style="text-align: center;"><strong>Schematic of PROTEUS components and corresponding modules.</strong></p>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,15 +1,16 @@
-.arch-diagram {
+.mod-diagram {
   width: 100%;
+  height: auto;
+  aspect-ratio: 12.1 / 9;  /* specific aspect ratio for the module diagram */
   display: none;
 }
-
 /* Light mode: show light diagram */
-[data-md-color-scheme="default"] .arch-diagram--light {
+[data-md-color-scheme="default"] .mod-diagram--light {
   display: block;
 }
 
 /* Dark mode: show dark diagram (Material's default dark scheme is "slate") */
-[data-md-color-scheme="slate"] .arch-diagram--dark {
+[data-md-color-scheme="slate"] .mod-diagram--dark {
   display: block;
 }
 


### PR DESCRIPTION
## Description
This PR should fix the image rendering issues that arose since the latest merge. 

It updates the logo paths in index.md and README, and uses `jsdelivr` to hotlink to the PROTEUS schematic, which is otherwise automatically blocked by Github when using an <object>. 

## Validation of changes
Built the docs locally on safari and chrome.


## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people
@nichollsh 
