### PR TITLE
Fix mermaid issue: pin zensical to newest version (0.0.43)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -18,3 +18,8 @@
 .md-typeset p a:has(> img) {
   text-decoration: none;
 }
+
+.mod-diagram:focus,
+.mod-diagram:focus-visible {
+    outline: none !important;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -19,6 +19,7 @@
   text-decoration: none;
 }
 
+/* Remove focus outline from module diagrams for Firefox */
 .mod-diagram:focus,
 .mod-diagram:focus-visible {
     outline: none !important;

--- a/docs/stylesheets/footnotes.css
+++ b/docs/stylesheets/footnotes.css
@@ -17,13 +17,3 @@
   vertical-align: baseline !important;
   font-size: 1em !important;
 }
-
-/* reduce space under the page title */
-.md-typeset h1 {
-  margin-bottom: 0.2rem;  /* try 0, 0.2rem, 0.5rem */
-}
-
-/* optionally reduce any top margin on the first image */
-.md-typeset h1 + p img {
-  margin-top: 0;
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ develop = [
   "pytest"
 ]
 docs = [
-    "zensical==0.0.39",
+    "zensical==0.0.43",
     "markdown-include",
     "mkdocs",
     "mkdocs-material",


### PR DESCRIPTION
## Description

Two new Zensical versions have appeared since the problematic version 0.0.41, which led me to pinning Zensical to an older version (0.0.39). However, the newest version supports the use of Mermaid diagrams, one of which is present in docs/Explanations/proteus.md, but it is currently not rendering. Pinning to this later version (0.0.43) should fix that. 

Additionally, a small CSS fix has been introduced for Firefox to remove the outline that sometimes appears after clicking on any diagram link.

## Validation of changes
I built the docs locally on chrome, safari and firefox. 

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people
@nichollsh 
