### PR TITLE
Publish a live test-count badge from CI

### DIFF
--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -1,0 +1,166 @@
+name: Refresh test count badges
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'tests/**'
+      - 'src/zephyrus/**'
+      - 'pyproject.toml'
+      - 'tools/generate_test_badges.py'
+      - '.github/workflows/publish-test-badges.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: badges-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  refresh-badges:
+    name: Regenerate tests-total.json
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Guard against publishing from a non-main ref
+        # The push trigger is already main-only, but workflow_dispatch can
+        # be launched from any branch. Publishing another ref's test count
+        # to the public badge would be misleading, so refuse it loudly.
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Badges may only be published from main; this run is on ${{ github.ref }}." >&2
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ZEPHYRUS and pytest
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[develop]"
+
+      - name: Regenerate badge JSON files
+        run: |
+          python tools/generate_test_badges.py --out badge_payload/
+
+      - name: Publish badges to the badges branch
+        # The ``main`` ruleset blocks direct pushes, so the badge JSON is
+        # published to a dedicated ``badges`` branch that lives outside that
+        # ruleset rather than committed back onto ``main``. shields.io reads
+        # the JSON from the raw URL of this branch. The branch carries only
+        # the JSON file plus a README; consumers that need the source tree
+        # use ``main``. The test workflow triggers only on ``main``, and the
+        # commit is marked ``[skip ci]``, so a badge refresh never starts a
+        # test run against the source-less tree.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          payload="${GITHUB_WORKSPACE}/badge_payload"
+          remote="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          branch="badges"
+
+          # Refuse to publish a partial or malformed set: a generator
+          # regression that drops the file or emits invalid JSON would
+          # otherwise leave a badge silently stale or broken behind a green
+          # check. Validate names and shields schema before touching the
+          # remote.
+          python3 - "${payload}" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = Path(sys.argv[1])
+          expected = ('tests-total.json',)
+          for name in expected:
+              path = payload / name
+              if not path.is_file():
+                  sys.exit(f'Missing badge file: {path}')
+              data = json.loads(path.read_text())
+              if data.get('schemaVersion') != 1 or not str(data.get('message', '')).strip():
+                  sys.exit(f'Malformed badge file: {path}')
+          print(f'Validated {len(expected)} badge file(s).')
+          PY
+
+          # Each fallible step returns explicitly: the function is invoked
+          # from a conditional, which disables ``set -e`` inside it, so a
+          # failure must be propagated by hand rather than relied on to
+          # abort. Returns 0 on a successful push or a no-op, 1 on a
+          # retryable failure.
+          attempt_publish() {
+            local work exists rc
+
+            # Tell "branch absent" (ls-remote exit 2) apart from an
+            # unreachable remote (network/auth, other non-zero), so a
+            # transient failure is retried instead of being mistaken for an
+            # empty branch and overwritten with a root commit.
+            if git ls-remote --exit-code --heads "${remote}" "${branch}" >/dev/null 2>&1; then
+              exists=1
+            else
+              rc=$?
+              if [ "${rc}" -eq 2 ]; then
+                exists=0
+              else
+                echo "Could not reach the remote to check ${branch} (rc=${rc})." >&2
+                return 1
+              fi
+            fi
+
+            work="$(mktemp -d)" || return 1
+            cd "${work}" || return 1
+            git init -q || return 1
+
+            if [ "${exists}" -eq 1 ]; then
+              git fetch -q "${remote}" "${branch}" || return 1
+              git checkout -q FETCH_HEAD || return 1
+              # Drop everything the branch carried so the new commit holds
+              # only the freshly generated files; a stale leftover would
+              # otherwise survive the checkout-and-overwrite.
+              git rm -rfq --ignore-unmatch . >/dev/null 2>&1 || return 1
+            fi
+
+            cp "${payload}"/tests-*.json . || return 1
+            printf '%s\n' \
+              '# Test count badges' \
+              '' \
+              'Machine-generated by the `Refresh test count badges` workflow that runs on `main`.' \
+              'shields.io endpoint badges read these JSON files by raw URL.' \
+              'Do not edit or delete this branch by hand; the source lives on `main`.' \
+              > README.md || return 1
+            git add tests-*.json README.md || return 1
+
+            if [ "${exists}" -eq 1 ] && git diff --cached --quiet; then
+              echo "Badge counts unchanged; nothing to publish."
+              return 0
+            fi
+
+            git -c user.name="actions" -c user.email="actions@github.com" \
+              commit -qm "Update test count badges [skip ci]" || return 1
+            git push -q "${remote}" "HEAD:refs/heads/${branch}" || return 1
+            echo "Published refreshed badges to the ${branch} branch."
+            return 0
+          }
+
+          # The concurrency group serialises runs on ``main``, so a competing
+          # run cannot move the branch tip mid-push; the retry only covers a
+          # transient network or fetch hiccup. Each attempt re-checks the
+          # branch state from a clean working tree.
+          for attempt in 1 2 3; do
+            if attempt_publish; then
+              exit 0
+            fi
+            echo "Publish attempt ${attempt} failed; retrying."
+            sleep 2
+          done
+          echo "Failed to publish badges after 3 attempts." >&2
+          exit 1

--- a/.github/workflows/publish-test-badges.yml
+++ b/.github/workflows/publish-test-badges.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install ZEPHYRUS and pytest
         run: |
           python -m pip install --upgrade pip
-          pip install ".[develop]"
+          python -m pip install ".[develop]"
 
       - name: Regenerate badge JSON files
         run: |
@@ -75,7 +75,7 @@ jobs:
           # otherwise leave a badge silently stale or broken behind a green
           # check. Validate names and shields schema before touching the
           # remote.
-          python3 - "${payload}" <<'PY'
+          python - "${payload}" <<'PY'
           import json
           import sys
           from pathlib import Path

--- a/docs/Explanations/testing.md
+++ b/docs/Explanations/testing.md
@@ -1,0 +1,15 @@
+# Testing suite
+
+![coverage](https://gist.githubusercontent.com/lsoucasse/152250f71914339d24537977e64aba55/raw/covbadge_zephyrus.svg)
+[![Tests](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml)
+[![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/badges/tests-total.json)](https://proteus-framework.org/testing)
+
+The badge shows the number of tests in the suite. It reads a small JSON file on the repository's `badges` branch that the `Refresh test count badges` workflow regenerates whenever the test suite or source changes on `main`, so the count stays current without hand editing. The same file backs the module's row on the central [PROTEUS testing dashboard](https://proteus-framework.org/testing).
+
+The suite is a regression net: a passing run confirms that recent changes have not perturbed locked behaviour, not that the behaviour is itself physically correct. Physical correctness is judged separately, against analytic limits, benchmark codes, and published references.
+
+## Badge system
+
+`tests-total.json` sits at the root of the `badges` branch in the shields.io endpoint schema. Publishing to a dedicated branch keeps the generated file off `main`, where direct pushes need review. The `Refresh test count badges` workflow regenerates the count whenever the test suite or source changes on `main` and publishes it there; shields.io fetches it live.
+
+For how to run the suite, see [Run tests](../How-to/run_tests.md).

--- a/docs/Explanations/testing.md
+++ b/docs/Explanations/testing.md
@@ -1,7 +1,7 @@
 # Testing suite
 
 ![coverage](https://gist.githubusercontent.com/lsoucasse/152250f71914339d24537977e64aba55/raw/covbadge_zephyrus.svg)
-[![Tests](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml/badge.svg?branch=main)](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/FormingWorlds/ZEPHYRUS/tests.yaml?branch=main&label=Tests)](https://github.com/FormingWorlds/ZEPHYRUS/actions/workflows/tests.yaml)
 [![tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/FormingWorlds/ZEPHYRUS/badges/tests-total.json)](https://proteus-framework.org/testing)
 
 The badge shows the number of tests in the suite. It reads a small JSON file on the repository's `badges` branch that the `Refresh test count badges` workflow regenerates whenever the test suite or source changes on `main`, so the count stays current without hand editing. The same file backs the module's row on the central [PROTEUS testing dashboard](https://proteus-framework.org/testing).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ nav:
       - Model overview: Explanations/model.md
       - Coupling to PROTEUS: Explanations/proteus.md
       - Limitations: Explanations/limitations.md
+      - Testing suite: Explanations/testing.md
 
   - Reference:
       - Model parameters: Reference/parameters.md

--- a/tools/generate_test_badges.py
+++ b/tools/generate_test_badges.py
@@ -62,7 +62,7 @@ def count_tests(marker_expr: str) -> int:
         trailing summary line cannot be parsed from stdout.
     """
     proc = subprocess.run(
-        ['pytest', '--collect-only', '-q', '-m', marker_expr],
+        [sys.executable, '-m', 'pytest', '--collect-only', '-q', '-m', marker_expr],
         check=False,
         capture_output=True,
         text=True,

--- a/tools/generate_test_badges.py
+++ b/tools/generate_test_badges.py
@@ -1,0 +1,146 @@
+"""Generate a shields.io endpoint-badge JSON file for the test count.
+
+The script invokes ``pytest --collect-only -q`` to count tests without
+executing them, then writes the count to a JSON file under the ``--out``
+directory in the shields.io endpoint-badge schema:
+
+    {"schemaVersion": 1, "label": "<text>", "message": "<count>", "color": "blue"}
+
+Output is a single file, ``tests-total.json`` (label "tests"), holding the
+count of ``not skip`` tests. The suite carries no unit/integration marker
+split, so the badge reports one total. A marker split can be added later by
+extending ``_BADGES`` with the extra expressions.
+
+Usage
+-----
+    python tools/generate_test_badges.py --out <dir>
+
+The publish workflow points ``--out`` at a scratch directory and copies the
+resulting JSON onto the ``badges`` branch, which shields.io reads by raw URL.
+
+Notes
+-----
+Running the script does not execute the test suite; only collection is
+triggered. Pytest exit code 5 ("no tests collected") is treated as a
+successful zero count and the badge writes ``"message": "0"``. Any other
+non-zero exit is a hard failure, so an incomplete install that breaks
+collection fails the run loudly instead of publishing a wrong count.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_COLLECT_RE = re.compile(r'^(\d+)(?:/\d+)?\s+tests?\s+collected\b', re.MULTILINE)
+
+_BADGES: tuple[tuple[str, str, str], ...] = (('total', 'tests', 'not skip'),)
+
+
+def count_tests(marker_expr: str) -> int:
+    """Run pytest collection and return the number of selected tests.
+
+    Parameters
+    ----------
+    marker_expr : str
+        Pytest marker expression passed via ``-m``.
+
+    Returns
+    -------
+    int
+        Number of tests pytest collected for the given marker. Exit
+        code 5 ("no tests collected") is mapped to 0.
+
+    Raises
+    ------
+    RuntimeError
+        If pytest exits with a non-zero code other than 5, or if the
+        trailing summary line cannot be parsed from stdout.
+    """
+    proc = subprocess.run(
+        ['pytest', '--collect-only', '-q', '-m', marker_expr],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 5:
+        return 0
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f'pytest --collect-only -m {marker_expr!r} exited with '
+            f'code {proc.returncode}\n'
+            f'--- stdout ---\n{proc.stdout}\n'
+            f'--- stderr ---\n{proc.stderr}'
+        )
+    match = _COLLECT_RE.search(proc.stdout)
+    if match is None:
+        raise RuntimeError(
+            f'pytest summary line not found for marker {marker_expr!r}\n'
+            f'--- stdout ---\n{proc.stdout}'
+        )
+    return int(match.group(1))
+
+
+def write_badge(out_dir: Path, name: str, label: str, count: int) -> Path:
+    """Write a shields.io endpoint-badge JSON file.
+
+    Parameters
+    ----------
+    out_dir : Path
+        Directory to write the JSON file into. Must already exist.
+    name : str
+        Suffix used in the filename ``tests-<name>.json``.
+    label : str
+        Badge label rendered on the left side of the shield.
+    count : int
+        Badge message count rendered on the right side of the shield.
+
+    Returns
+    -------
+    Path
+        Path of the written JSON file.
+    """
+    payload = {
+        'schemaVersion': 1,
+        'label': label,
+        'message': str(count),
+        'color': 'blue',
+    }
+    out_path = out_dir / f'tests-{name}.json'
+    out_path.write_text(json.dumps(payload, indent=2) + '\n', encoding='utf-8')
+    return out_path
+
+
+def main() -> int:
+    """Entry point.
+
+    Returns
+    -------
+    int
+        Process exit code (always 0 on success; failures raise).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--out',
+        type=Path,
+        required=True,
+        help='Directory to write tests-<name>.json badge files into.',
+    )
+    args = parser.parse_args()
+    out_dir: Path = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    for name, label, expr in _BADGES:
+        count = count_tests(expr)
+        write_badge(out_dir, name, label, count)
+        print(f'{label}: {count}')
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Description
This adds a live shields.io test-count badge for ZEPHYRUS. A workflow on main regenerates the count whenever the test suite, the package, or the project config changes, and publishes it so the documentation site can show a live number instead of a hand-maintained one that drifts.

The main branch requires pull-request review, so the workflow cannot push the refreshed JSON back onto main. It publishes to a dedicated badges branch that carries only the generated file plus a short README, which shields.io reads by raw URL.

Changes:

- tools/generate_test_badges.py counts collected tests and writes tests-total.json in the shields.io endpoint schema.
- The Refresh test count badges workflow runs on main, regenerates the count, and publishes it to the badges branch.
- The badge reports a single total, since the suite has no unit/integration marker split.

## Validation of changes
I ran the generator locally against the current suite: it collected 3 tests and wrote a well-formed tests-total.json. The badges branch push does not trigger the test, docs, or publish workflows, since those run only on main or on release, and the commit is marked to skip CI. Tested on macOS with Python 3.12.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required

## Relevant people
The proteus-framework.org testing page will point its ZEPHYRUS row at this badge once it publishes on main.
