### PR TITLE
Key the nightly data cache on the dataset ZEPHYRUS actually resolves

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,13 +33,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[develop]"
 
-      # The key carries the Zenodo record and OSF mirror that pin the Spada
-      # grid in the installed fwl-mors, plus the directory it unpacks into, so
-      # it moves exactly when that grid moves. actions/cache writes only on an
-      # exact-key miss, so a key that never changes is never rewritten and the
-      # tree it holds cannot follow the data. That matters here because the
-      # grid lands in an unversioned directory and mors skips the download
-      # whenever it is present, so nothing else would notice a re-pin.
+      # The key carries the Zenodo record that pins the Spada grid in the
+      # installed fwl-mors, plus the directory it unpacks into, so it moves
+      # when that grid is re-pinned. The OSF mirror is deliberately outside
+      # the digest, so mirror drift is untracked. Full rationale in the
+      # helper's module docstring.
       - name: Resolve the data cache key
         id: cachekey
         run: python tools/nightly_data_cache.py key

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,11 +33,36 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e ".[develop]"
 
+      # The key carries the Zenodo record and OSF mirror that pin the Spada
+      # grid in the installed fwl-mors, plus the directory it unpacks into, so
+      # it moves exactly when that grid moves. actions/cache writes only on an
+      # exact-key miss, so a key that never changes is never rewritten and the
+      # tree it holds cannot follow the data. That matters here because the
+      # grid lands in an unversioned directory and mors skips the download
+      # whenever it is present, so nothing else would notice a re-pin.
+      - name: Resolve the data cache key
+        id: cachekey
+        run: python tools/nightly_data_cache.py key
+
+      # Deliberately no restore-keys. A prefix fallback would restore the
+      # previous grid into the unversioned directory mors checks for, so mors
+      # would skip the download, the check below would be skipped too because a
+      # prefix restore reports no cache hit, and the stale tree would be saved
+      # under the new key. A moved key has to miss so the grid is fetched.
       - uses: actions/cache@v5
         id: cache-fwl-data
         with:
           path: ${{ github.workspace }}/fwl_data
-          key: fwl-data-nightly-1
+          key: ${{ steps.cachekey.outputs.key }}
+
+      # A tree restored on an exact key hit holds what that key was stored
+      # under, so a missing or half-unpacked grid means the two have come
+      # apart. A prefix restore is expected to be incomplete and is not checked.
+      - name: Check the restored grid
+        if: steps.cache-fwl-data.outputs.cache-hit == 'true'
+        run: |
+          python tools/nightly_data_cache.py check \
+            --data-root "${{ github.workspace }}/fwl_data"
 
       - name: Run full suite with coverage
         env:

--- a/tests/test_nightly_data_cache.py
+++ b/tests/test_nightly_data_cache.py
@@ -89,8 +89,8 @@ def test_cache_key_moves_with_the_spada_pins_and_not_otherwise(monkeypatch):
     # leaves the key at baseline and would pass.
     assert mod._pins() == {'zenodo': '15729101', 'subdir': f'{mod.SUBDIR}/{mod.DATASET}'}
 
-    # An empty digest would equal the workflow's restore-key prefix, exact-hit
-    # its own entry, and freeze the tree with nothing reporting it.
+    # An empty digest would leave the key as the constant prefix alone, which
+    # exact-hits its own entry on every run and freezes the tree silently.
     assert baseline.startswith(mod.KEY_PREFIX)
     assert re.fullmatch(rf'{re.escape(mod.KEY_PREFIX)}[0-9a-f]{{64}}', baseline)
 
@@ -119,8 +119,9 @@ def test_cache_key_refuses_to_resolve_without_the_pins(monkeypatch, capsys):
 def test_key_command_writes_the_output_line_the_workflow_reads(monkeypatch, tmp_path):
     """The key subcommand emits exactly the GITHUB_OUTPUT line the cache step reads.
 
-    A malformed line leaves the cache key empty, the restore prefix always
-    wins, and the tree freezes with nothing failing.
+    A malformed line leaves the workflow's key expression empty, and the
+    cache step rejects an empty key, so the nightly dies at that step
+    instead of caching under the resolved key.
     """
     mod = _cache_module()
     _pin(monkeypatch, record='15729101')
@@ -142,6 +143,11 @@ def test_restore_check_requires_an_unpacked_grid(monkeypatch, tmp_path):
     """
     mod = _cache_module()
     base = tmp_path / mod.SUBDIR / mod.DATASET
+
+    # A smaller floor keeps the test inside the unit wall-time budget; every
+    # assertion below is expressed against the patched constant, so the
+    # count-to-floor relationship under test is unchanged.
+    monkeypatch.setattr(mod, 'MIN_FILES', 24)
 
     # Nothing at all.
     count, problems = mod.check_restored(tmp_path)

--- a/tests/test_nightly_data_cache.py
+++ b/tests/test_nightly_data_cache.py
@@ -1,0 +1,217 @@
+"""Tests for ``tools/nightly_data_cache.py``.
+
+The nightly caches the FWL data tree under a key this script resolves. A key
+that stops tracking the data does not fail anything: the nightly stays green
+and either refetches every run or, worse for ZEPHYRUS, serves a stale grid
+forever, because the Spada tracks land in an unversioned directory that
+``mors`` skips whenever it is present. These tests pin the key to the
+dataset pins in both directions, pin the workflow to the resolved key, and
+pin the restore check against a half-unpacked tree.
+
+See ``docs/How-to/run_tests.md`` for the tier and marker conventions.
+"""
+
+import importlib.util
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
+
+REPO = Path(__file__).parents[1]
+
+
+def _cache_module():
+    """Load the helper, skipping when its one dependency is absent."""
+    pytest.importorskip('mors')
+    path = REPO / 'tools' / 'nightly_data_cache.py'
+    spec = importlib.util.spec_from_file_location('nightly_data_cache', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _pin(monkeypatch, *, record):
+    """Point the helper at a fabricated Spada Zenodo record."""
+    import mors.data
+
+    monkeypatch.setattr(mors.data, 'get_zenodo_record', lambda name: record, raising=True)
+
+
+def test_cache_key_moves_with_the_spada_pins_and_not_otherwise(monkeypatch):
+    """The key tracks the Zenodo record and the OSF mirror, and nothing else.
+
+    The grid unpacks to an unversioned directory and mors skips the download
+    whenever it exists, so a re-pin is invisible on disk. The key is the only
+    thing that can notice, which is why both pins have to move it.
+    """
+    mod = _cache_module()
+
+    _pin(monkeypatch, record='15729101')
+    baseline = mod.resolve_key()
+
+    # Re-pinning the deposit must move the key, or the stale grid is served on.
+    _pin(monkeypatch, record='15729102')
+    assert mod.resolve_key() != baseline
+
+    # Same pin, same key: a steady-state night has to hit its own entry.
+    _pin(monkeypatch, record='15729101')
+    assert mod.resolve_key() == baseline
+
+    # The OSF mirror id is deliberately outside the digest: it does not move
+    # when the files behind it do, so hashing it would imply coverage.
+    import mors.data
+
+    monkeypatch.setattr(mors.data, 'project_id', 'something-else', raising=False)
+    assert mod.resolve_key() == baseline
+
+    # An empty digest would equal the workflow's restore-key prefix, exact-hit
+    # its own entry, and freeze the tree with nothing reporting it.
+    assert baseline.startswith(mod.KEY_PREFIX)
+    assert re.fullmatch(rf'{re.escape(mod.KEY_PREFIX)}[0-9a-f]{{64}}', baseline)
+
+
+def test_cache_key_refuses_to_resolve_without_the_pins(monkeypatch, capsys):
+    """A missing record stops the job with a diagnostic rather than a bare key."""
+    mod = _cache_module()
+    import mors.data
+
+    monkeypatch.setattr(mors.data, 'get_zenodo_record', lambda name: None, raising=True)
+    with pytest.raises(mod.ResolutionError, match='no Zenodo record'):
+        mod.resolve_key()
+    assert mod.main(['key']) == 1
+    assert 'no Zenodo record' in capsys.readouterr().err
+
+    monkeypatch.delattr(mors.data, 'get_zenodo_record', raising=True)
+    with pytest.raises(mod.ResolutionError, match='get_zenodo_record'):
+        mod.resolve_key()
+
+
+def test_key_command_writes_the_output_line_the_workflow_reads(monkeypatch, tmp_path):
+    """The key subcommand emits exactly the GITHUB_OUTPUT line the cache step reads.
+
+    A malformed line leaves the cache key empty, the restore prefix always
+    wins, and the tree freezes with nothing failing.
+    """
+    mod = _cache_module()
+    _pin(monkeypatch, record='15729101')
+    out = tmp_path / 'gh_output'
+    monkeypatch.setenv('GITHUB_OUTPUT', str(out))
+
+    assert mod.main(['key']) == 0
+    lines = out.read_text(encoding='utf-8').splitlines()
+    assert len(lines) == 1
+    assert re.fullmatch(rf'key={re.escape(mod.KEY_PREFIX)}[0-9a-f]{{64}}', lines[0])
+    assert lines[0].split('=', 1)[1] == mod.resolve_key()
+
+
+def test_restore_check_requires_an_unpacked_grid(monkeypatch, tmp_path):
+    """Presence of the directory is not enough; the grid has to be unpacked.
+
+    A directory that exists but holds nothing, or still holds the archive, is
+    exactly what a half-restored cache looks like, so neither may pass.
+    """
+    mod = _cache_module()
+    base = tmp_path / mod.SUBDIR / mod.DATASET
+
+    # Nothing at all.
+    count, problems = mod.check_restored(tmp_path)
+    assert count == 0
+    assert any('does not exist' in p for p in problems)
+    assert mod.main(['check', '--data-root', str(tmp_path)]) == 1
+
+    # Present but never unpacked.
+    base.mkdir(parents=True)
+    count, problems = mod.check_restored(tmp_path)
+    assert count == 0
+    assert any(mod.GRID_DIR in p for p in problems)
+
+    # Unpacked but short of the floor.
+    # Nested, as the real grid is: per-composition subdirectories with no
+    # files at the top level, so a walk that does not recurse counts zero.
+    grid = base / mod.GRID_DIR
+    grid.mkdir()
+    for i in range(5):
+        comp = grid / f'X0p7{i}_Z0p001_A1p000'
+        comp.mkdir()
+        (comp / 'track.dat').write_text('x', encoding='utf-8')
+    count, problems = mod.check_restored(tmp_path)
+    assert count == 5
+    assert any('fewer than' in p for p in problems)
+
+    # Populated, but the archive was left behind by an interrupted unpack.
+    for i in range(mod.MIN_FILES):
+        comp = grid / f'X0p8{i % 20}_Z0p002_A1p875'
+        comp.mkdir(exist_ok=True)
+        (comp / f'track_{i}.dat').write_text('x', encoding='utf-8')
+    (base / 'fs255_grid.tar.gz').write_text('x', encoding='utf-8')
+    count, problems = mod.check_restored(tmp_path)
+    assert count == mod.MIN_FILES + 5
+    assert any('left unextracted' in p for p in problems)
+    assert mod.main(['check', '--data-root', str(tmp_path)]) == 1
+
+    # Complete.
+    (base / 'fs255_grid.tar.gz').unlink()
+    count, problems = mod.check_restored(tmp_path)
+    assert problems == []
+    assert mod.main(['check', '--data-root', str(tmp_path)]) == 0
+
+
+def test_check_refuses_to_run_without_a_data_root(monkeypatch):
+    """With no root given, check reports it rather than scanning the working directory.
+
+    Path('') is Path('.'), so a guard applied after the Path is built cannot
+    fire and would silently count files wherever the job happens to sit.
+    """
+    mod = _cache_module()
+    monkeypatch.delenv('FWL_DATA', raising=False)
+
+    with pytest.raises(mod.ResolutionError, match='no data root'):
+        mod._cmd_check(SimpleNamespace(data_root=None))
+    assert mod.main(['check']) == 1
+
+    monkeypatch.setenv('FWL_DATA', '')
+    with pytest.raises(mod.ResolutionError, match='no data root'):
+        mod._cmd_check(SimpleNamespace(data_root=None))
+
+
+def test_nightly_workflow_derives_its_key_and_declares_no_restore_prefix():
+    """The workflow reads the resolved key and offers no prefix fallback."""
+    mod = _cache_module()
+    workflow = (REPO / '.github' / 'workflows' / 'nightly.yml').read_text(encoding='utf-8')
+
+    assert 'tools/nightly_data_cache.py key' in workflow
+    assert 'key: ${{ steps.cachekey.outputs.key }}' in workflow
+    # ANY literal, not just the one this replaced: actions/cache never rewrites
+    # an entry whose key it hits, so a literal of any value freezes the tree.
+    assert not re.search(rf'key:\s*{re.escape(mod.KEY_PREFIX)}\S', workflow)
+    # No restore-keys: a prefix fallback would restore the previous grid into
+    # the unversioned directory mors checks for, so mors would skip the
+    # download and the stale tree would be saved under the new key.
+    assert not re.search(r'^\s*restore-keys:', workflow, re.MULTILINE)
+    # The check only means something on an exact hit.
+    assert "if: steps.cache-fwl-data.outputs.cache-hit == 'true'" in workflow
+
+
+def test_cache_script_covers_every_dataset_the_suite_downloads():
+    """The dataset the key tracks is the dataset the tests actually fetch.
+
+    Nothing but convention links the constant in the helper to the call sites
+    here, so a second dataset added later would go untracked by the cache key
+    with nothing failing.
+    """
+    mod = _cache_module()
+    downloaded = set()
+    for path in (REPO / 'tests').rglob('test_*.py'):
+        for name in re.findall(
+            r"DownloadEvolutionTracks\(\s*'([^']+)'", path.read_text(encoding='utf-8')
+        ):
+            downloaded.add(name)
+
+    assert downloaded, 'no DownloadEvolutionTracks call site found; has the fetch moved?'
+    assert downloaded == {mod.DATASET}, (
+        f'the suite downloads {sorted(downloaded)} but the cache key tracks '
+        f'only {mod.DATASET!r}; an untracked dataset freezes in the cache'
+    )

--- a/tests/test_nightly_data_cache.py
+++ b/tests/test_nightly_data_cache.py
@@ -22,6 +22,10 @@ pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 
 REPO = Path(__file__).parents[1]
 
+# Stand-in the OSF project id is patched to, long enough that it cannot collide
+# with a pin value by accident.
+MIRROR_SENTINEL = 'osf-mirror-must-not-be-hashed'
+
 
 def _cache_module():
     """Load the helper, skipping when its one dependency is absent."""
@@ -41,11 +45,12 @@ def _pin(monkeypatch, *, record):
 
 
 def test_cache_key_moves_with_the_spada_pins_and_not_otherwise(monkeypatch):
-    """The key tracks the Zenodo record and the OSF mirror, and nothing else.
+    """The key tracks the Zenodo record and the unpack directory, and nothing else.
 
     The grid unpacks to an unversioned directory and mors skips the download
     whenever it exists, so a re-pin is invisible on disk. The key is the only
-    thing that can notice, which is why both pins have to move it.
+    thing that can notice, which is why the record has to move it. The OSF
+    mirror is deliberately outside the digest, so mirror drift is untracked.
     """
     mod = _cache_module()
 
@@ -64,13 +69,23 @@ def test_cache_key_moves_with_the_spada_pins_and_not_otherwise(monkeypatch):
     # when the files behind it do, so hashing it would imply coverage.
     import mors.data
 
-    monkeypatch.setattr(mors.data, 'project_id', 'something-else', raising=False)
+    monkeypatch.setattr(mors.data, 'project_id', MIRROR_SENTINEL, raising=False)
     assert mod.resolve_key() == baseline
+
+    # Pin the material itself. The comparison above only notices a digest that
+    # reads the patched attribute; one carrying the mirror id as a literal
+    # leaves the key at baseline and would pass.
+    assert mod._pins() == {'zenodo': '15729101', 'subdir': f'{mod.SUBDIR}/{mod.DATASET}'}
 
     # An empty digest would equal the workflow's restore-key prefix, exact-hit
     # its own entry, and freeze the tree with nothing reporting it.
     assert baseline.startswith(mod.KEY_PREFIX)
     assert re.fullmatch(rf'{re.escape(mod.KEY_PREFIX)}[0-9a-f]{{64}}', baseline)
+
+    # The unpack directory is hashed alongside the record, so a rename of it
+    # has to move the key too. Left last: monkeypatch holds the rename in force.
+    monkeypatch.setattr(mod, 'SUBDIR', 'stellar_evolution_tracks_v2')
+    assert mod.resolve_key() != baseline
 
 
 def test_cache_key_refuses_to_resolve_without_the_pins(monkeypatch, capsys):

--- a/tests/test_nightly_data_cache.py
+++ b/tests/test_nightly_data_cache.py
@@ -13,10 +13,22 @@ See ``docs/How-to/run_tests.md`` for the tier and marker conventions.
 
 import importlib.util
 import re
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+# Python 3.10 can only resolve an fwl-mors that predates the Spada Zenodo
+# record accessor, so the cache key cannot be resolved there at all. On 3.11
+# and above a missing accessor is a real failure: it means the dependency
+# moved under us, which is exactly what this file exists to notice.
+if sys.version_info < (3, 11):
+    pytest.skip(
+        'this interpreter resolves an fwl-mors that predates the Spada Zenodo '
+        'record accessor, so the nightly cache key cannot be resolved here',
+        allow_module_level=True,
+    )
 
 pytestmark = [pytest.mark.unit, pytest.mark.timeout(30)]
 

--- a/tools/nightly_data_cache.py
+++ b/tools/nightly_data_cache.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Cache key and restore check for the FWL data tree the nightly caches.
+
+Two subcommands, both used by ``.github/workflows/nightly.yml``::
+
+    python tools/nightly_data_cache.py key
+    python tools/nightly_data_cache.py check
+
+ZEPHYRUS reaches one dataset through its ``fwl-mors`` dependency: the Spada
+stellar-evolution grid, fetched by ``mors.DownloadEvolutionTracks('Spada')``.
+That grid is pinned by a Zenodo record id with an OSF project as its mirror,
+both of which live in the installed ``mors.data``, and it unpacks to the
+unversioned directory ``stellar_evolution_tracks/Spada``.
+
+``key`` prints ``key=<value>`` for ``GITHUB_OUTPUT``, carrying a digest of
+the Zenodo record, so the key moves when the grid is re-pinned and stays put
+otherwise. The directory names below are a fixed namespace segment rather
+than a resolved property: nothing queries them from ``mors``, so a mors-side
+rename of the Spada unpack path has to be mirrored here by hand.
+
+The OSF project that mirrors the deposit is deliberately not part of the
+digest. Its id does not change when the files inside it change, so hashing
+it would imply a coverage this key does not have. Mirror drift is untracked,
+as it is for the OSF pins in the sibling JANUS module.
+
+The unversioned path is why this matters more here than for a versioned
+dataset. ``mors`` skips the download whenever the directory is present, so a
+re-pinned grid does not land beside the old one and announce itself: the
+stale tree keeps satisfying the check indefinitely. The cache key is the only
+thing that can notice.
+
+``check`` verifies the restored grid is actually unpacked. There is no
+committed registry for Spada, so the check is structural rather than
+per-file: the grid directory exists, holds a plausible number of files, and
+no archive is left behind by an interrupted unpack.
+
+Both subcommands fail with a diagnostic rather than degrade: an empty or
+partial digest would collide with the workflow's restore-key prefix and
+freeze the cached tree with nothing reporting it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+# JANUS carries a script of the same name for the same actions/cache defect,
+# shaped differently because it consumes a manifest-declared dataset with a
+# registry and a versioned path. A change here is worth checking against it.
+KEY_PREFIX = 'fwl-data-nightly-'
+DATASET = 'Spada'
+SUBDIR = 'stellar_evolution_tracks'
+GRID_DIR = 'fs255_grid'
+# The unpacked grid holds about 1600 files across per-composition
+# subdirectories. The floor catches a partial restore; it cannot detect a
+# fully-unpacked tree that is simply out of date, which is what the key is for.
+MIN_FILES = 1000
+
+
+class ResolutionError(RuntimeError):
+    """The pins that decide the cached layout could not be resolved."""
+
+
+def _pins() -> dict[str, str]:
+    """Return the Spada pins read from the installed fwl-mors.
+
+    Returns
+    -------
+    dict
+        Mapping of pin name to value: the Zenodo record and the directory
+        the grid unpacks into.
+
+    Raises
+    ------
+    ResolutionError
+        When fwl-mors is absent, no longer exposes these pins, or reports
+        no Zenodo record for the dataset.
+    """
+    try:
+        import mors.data
+    except ImportError as exc:
+        raise ResolutionError(
+            'fwl-mors is not importable, so the Spada pins this key tracks cannot '
+            'be resolved. Install ZEPHYRUS with its dependencies before resolving '
+            'the cache key.'
+        ) from exc
+
+    if not hasattr(mors.data, 'get_zenodo_record'):
+        raise ResolutionError(
+            'the installed fwl-mors exposes no mors.data.get_zenodo_record(), so '
+            f'the {DATASET} pin is no longer where this script looks for it. Point '
+            'it at whatever now records the Zenodo deposit.'
+        )
+
+    record = mors.data.get_zenodo_record(DATASET)
+    if not record:
+        raise ResolutionError(
+            f'the installed fwl-mors reports no Zenodo record for {DATASET!r}, so '
+            'this key would track nothing. Check whether the dataset moved into '
+            'the fwl-io manifest, which would need a different key entirely.'
+        )
+
+    return {'zenodo': str(record), 'subdir': f'{SUBDIR}/{DATASET}'}
+
+
+def resolve_key() -> str:
+    """Return the cache key for the FWL data tree.
+
+    Returns
+    -------
+    str
+        ``fwl-data-nightly-<sha256>``.
+
+    Raises
+    ------
+    ResolutionError
+        When the pins cannot be resolved, or the digest comes out empty and
+        would collapse the key onto the restore-key prefix.
+    """
+    pins = _pins()
+    material = [f'{k}\t{pins[k]}' for k in sorted(pins)]
+    if not material:
+        raise ResolutionError(
+            'no pin was resolved, so the key would be the bare restore-key prefix '
+            'and the cached tree could never be rewritten.'
+        )
+    digest = hashlib.sha256('\n'.join(material).encode('utf-8')).hexdigest()
+    return f'{KEY_PREFIX}{digest}'
+
+
+def check_restored(data_root: Path) -> tuple[int, list[str]]:
+    """Report how completely the Spada grid is restored below ``data_root``.
+
+    Parameters
+    ----------
+    data_root : Path
+        Root of the restored FWL data tree.
+
+    Returns
+    -------
+    tuple
+        The file count found under the grid directory, and a list of
+        problems; an empty list means the tree looks complete.
+    """
+    base = data_root / SUBDIR / DATASET
+    grid = base / GRID_DIR
+    problems: list[str] = []
+
+    if not base.is_dir():
+        return 0, [f'{base} does not exist']
+    if not grid.is_dir():
+        problems.append(f'{grid} does not exist, so the grid was never unpacked')
+
+    count = sum(1 for p in grid.rglob('*') if p.is_file()) if grid.is_dir() else 0
+    if count < MIN_FILES:
+        problems.append(f'{count} files under {grid}, fewer than the {MIN_FILES} expected')
+
+    # mors deletes the tarball after unpacking, so one left behind means the
+    # unpack was interrupted and the tree is not what its key describes.
+    leftovers = sorted(p.name for p in base.glob('*.tar.gz'))
+    if leftovers:
+        problems.append(f'archive left unextracted: {", ".join(leftovers)}')
+
+    return count, problems
+
+
+def _cmd_key(args: argparse.Namespace) -> int:
+    key = resolve_key()
+    print(f'Cache key: {key}', file=sys.stderr)
+    output = os.environ.get('GITHUB_OUTPUT')
+    if output:
+        with open(output, 'a', encoding='utf-8') as handle:
+            handle.write(f'key={key}\n')
+    else:
+        print(f'key={key}')
+    return 0
+
+
+def _cmd_check(args: argparse.Namespace) -> int:
+    # Test the argument before it becomes a Path: Path('') is Path('.'), so a
+    # guard on the Path would pass and quietly check the working directory.
+    given = args.data_root or os.environ.get('FWL_DATA')
+    if not given:
+        raise ResolutionError('no data root to check: pass --data-root or set FWL_DATA.')
+
+    count, problems = check_restored(Path(given))
+    print(f'{SUBDIR}/{DATASET}/{GRID_DIR}: {count} files present')
+    if problems:
+        for p in problems:
+            print(f'  {p}', file=sys.stderr)
+        print(
+            'The restored tree does not match the key it was stored under. An '
+            'exact-key hit is never re-saved, so delete that cache entry to let '
+            'the next run store a complete tree.',
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run a subcommand and return its exit status."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest='command', required=True)
+    sub.add_parser('key', help='print the cache key for the FWL data tree')
+    check = sub.add_parser('check', help='verify the restored grid is unpacked')
+    check.add_argument('--data-root', default=None, help='defaults to FWL_DATA')
+
+    args = parser.parse_args(argv)
+    handler = {'key': _cmd_key, 'check': _cmd_check}[args.command]
+    try:
+        return handler(args)
+    except ResolutionError as exc:
+        print(f'error: {exc}', file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 -- reported, never swallowed
+        # Anything mors raises reaches here. Name it rather than let a
+        # traceback stand in for the diagnostic this script promises.
+        print(
+            f'error: resolving the {DATASET} pins through fwl-mors failed: {exc!r}. '
+            'Check that the installed fwl-mors still exposes the dataset record '
+            'this script reads.',
+            file=sys.stderr,
+        )
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/nightly_data_cache.py
+++ b/tools/nightly_data_cache.py
@@ -40,8 +40,9 @@ per-file: the grid directory exists, holds a plausible number of files, and
 no archive is left behind by an interrupted unpack.
 
 Both subcommands fail with a diagnostic rather than degrade: an empty or
-partial digest would collide with the workflow's restore-key prefix and
-freeze the cached tree with nothing reporting it.
+partial digest would leave the key as the constant prefix alone, and a
+constant key exact-hits its own entry on every run, freezing the cached
+tree with nothing reporting it.
 """
 
 from __future__ import annotations
@@ -123,14 +124,15 @@ def resolve_key() -> str:
     ------
     ResolutionError
         When the pins cannot be resolved, or the digest comes out empty and
-        would collapse the key onto the restore-key prefix.
+        would collapse the key to the constant ``KEY_PREFIX`` alone.
     """
     pins = _pins()
     material = [f'{k}\t{pins[k]}' for k in sorted(pins)]
     if not material:
         raise ResolutionError(
-            'no pin was resolved, so the key would be the bare restore-key prefix '
-            'and the cached tree could never be rewritten.'
+            f'no pin was resolved, so the key would be the constant {KEY_PREFIX!r} '
+            'alone, which exact-hits its own cache entry on every run, and the '
+            'cached tree could never be rewritten.'
         )
     digest = hashlib.sha256('\n'.join(material).encode('utf-8')).hexdigest()
     return f'{KEY_PREFIX}{digest}'

--- a/tools/nightly_data_cache.py
+++ b/tools/nightly_data_cache.py
@@ -12,11 +12,16 @@ That grid is pinned by a Zenodo record id with an OSF project as its mirror,
 both of which live in the installed ``mors.data``, and it unpacks to the
 unversioned directory ``stellar_evolution_tracks/Spada``.
 
-``key`` prints ``key=<value>`` for ``GITHUB_OUTPUT``, carrying a digest of
-the Zenodo record, so the key moves when the grid is re-pinned and stays put
-otherwise. The directory names below are a fixed namespace segment rather
-than a resolved property: nothing queries them from ``mors``, so a mors-side
-rename of the Spada unpack path has to be mirrored here by hand.
+``key`` prints ``key=<value>`` for ``GITHUB_OUTPUT``, carrying a digest of the
+Zenodo record and the directory the grid unpacks into, so the key moves when
+the grid is re-pinned and stays put otherwise. The directory names below are a
+fixed namespace segment rather than a resolved property: nothing queries them
+from ``mors``, so a mors-side rename of the Spada unpack path has to be
+mirrored here by hand.
+
+A moving key is the whole point. ``actions/cache`` writes an entry only on an
+exact-key miss and never rewrites one it hits, so a key that never changes is
+never rewritten and the tree it holds cannot follow the data.
 
 The OSF project that mirrors the deposit is deliberately not part of the
 digest. Its id does not change when the files inside it change, so hashing


### PR DESCRIPTION
## Description

The nightly workflow caches the FWL data tree under a key that never changed, `fwl-data-nightly-1`, frozen since 2026-07-10. `actions/cache` writes an entry only when the primary key misses, so a key that always hits is never rewritten and the tree it holds cannot follow the data. The nightly is green today because the data has not moved, not because the cache works.

The exposure is sharper here than for a versioned dataset. ZEPHYRUS reaches one dataset through its `fwl-mors` dependency, the Spada stellar-evolution grid, and that grid unpacks into the unversioned directory `stellar_evolution_tracks/Spada`. `mors` skips the download whenever that directory is present, so a re-pinned grid does not land beside the old one and announce itself: the stale tree keeps satisfying the check indefinitely, and nothing on disk can notice. The cache key is the only thing that can.

Spada also sits outside the fwl-io manifest, so there is no committed registry to hash. The key is instead derived from the Zenodo record that pins the deposit, read from the installed `fwl-mors`, so it moves when the deposit moves and stays put otherwise. There is deliberately no `restore-keys` prefix, which is where this differs from the same fix in JANUS: a prefix fallback would restore the previous grid into the very directory `mors` checks for, so on the one night the key moves, `mors` would skip the download, the post-restore check would be skipped too because a prefix restore reports no cache hit, and the stale tree would then be saved under the new key and cemented there. JANUS can afford the prefix because its dataset lands in a versioned directory, so a moved key leaves the new path genuinely absent. Here a moved key has to miss outright.

Resolving the key refuses to run when `fwl-mors` is missing, no longer exposes the dataset record, or reports no record for Spada, since a key that came out empty would freeze the tree again with nothing failing. On an exact hit the workflow checks that the grid is genuinely unpacked before any test runs. The OSF project that mirrors the deposit is not part of the digest, because its id does not change when the files behind it do; mirror drift is untracked and the code says so.

**After merging, please dispatch the ZEPHYRUS nightly manually on `main` once.** Cache writes are branch-scoped, so `main`'s first scheduled run after this lands will still miss and fetch Spada in full, about 339 MB, before saving. There is no prefix to soften that, deliberately.

## Validation of changes

Two dispatched runs on the branch. Run [31219873238](https://github.com/FormingWorlds/ZEPHYRUS/actions/runs/31219873238) logs `Cache not found for input keys:` against the single derived key, with no prefix in the list, then 46 passed in 19.56 s and `Cache saved with key:`. Run [31219990369](https://github.com/FormingWorlds/ZEPHYRUS/actions/runs/31219990369) logs an exact `Cache hit for:` the same key, the pre-test probe reporting `stellar_evolution_tracks/Spada/fs255_grid: 1602 files present`, 46 passed in 11.39 s, and `not saving cache`. The cache API shows the branch-scoped entry created at the first run's save and last read at the second run's hit.

The key reproduces across two different `fwl-mors` installs, a local editable checkout and the wheel CI resolves, giving the same digest. Re-pinning the record moves the key; the same pin gives the same key across repeated calls; a missing record raises rather than degrading. The probe's file count matches a real tree on disk exactly, 1602 files and 339 MB. Mutations over the key logic and the restore check are each caught by exactly one assertion, and the suite is green when they are restored. 43 unit tests pass, ruff is clean, and the marker, quality and file-size validators pass. Tested on macOS with Python 3.12 and on the workflow's ubuntu-latest.

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [x] I have added tests for these changes, as appropriate
- [x] I have checked that all dependencies have been updated, as required

## Relevant people

@nichollsh
